### PR TITLE
Add comprehensive FAQ documentation and bilingual documentation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,11 @@ Living documentation through the ray-tree command and semantic analysis.
 **[UNIX Pipes vs Ray.Framework](docs/unix-pipes-vs-ray-framework.md)**  
 Historical context: evolution from UNIX pipeline philosophy to typed domain object transformation.
 
-**[FAQ: A Dialogue with the Architect](docs/FAQ.md)**  
+**[FAQ: A Dialogue with the Architect](docs/FAQ-dialogue-with-architect.md)**  
 Common questions addressing practical concerns about existential explosion, immutability, and error handling.
+
+**[Semantic Variable Names](docs/FAQ-semantic-variable-names.md)**  
+Convention-based validation where naming eliminates redundant validation through the validates/ folder pattern.
 
 **[The #[Accept] Pattern: Ontological Delegation](docs/accept-pattern-ontological-delegation.md)**  
 Advanced pattern for handling undetermined states through responsible delegation to appropriate expertise.

--- a/docs/FAQ-dialogue-with-architect.md
+++ b/docs/FAQ-dialogue-with-architect.md
@@ -1,0 +1,55 @@
+# FAQ: A Dialogue with the Architect
+
+This document records a dialogue where an AI (Gemini Pro 2.5) posed a series of challenging questions to the architect to delve deeper into the design philosophy of this architecture. Each section includes the question, the architect's answer, and the key insights gained from the exchange, allowing readers to follow the thought process behind the design.
+
+---
+
+### 1. On the "Existential Explosion" and the Line Between Precision and Boilerplate
+
+**The Question:**
+This paradigm encourages the creation of many "small existences" like `NonEmptyString` or `VerifiedEmail`. In a large-scale application, this could lead to hundreds or thousands of such types. At what point do you think developers will start to perceive this "precision" as mere "boilerplate"? Where is the tipping point at which the value of safety provided by this paradigm is offset by the verbosity of the development experience?
+
+**The Architect's Answer:**
+> Are you afraid of 300 domain-specific string types? I am more afraid of 300 raw strings scattered throughout the codebase. In the age of AI, creating appropriate domain types with their corresponding validation is not a difficult task. It's not hard to establish that if you have a variable named `$email`, it should be of type `EmailAddress`, or if you have `$age`, it should be `NonNegativeInt`, and then generate the validation code. This code is then reusable. How about your application? In how many places is an email validated? In Ray, there is only one place.
+
+**Insight from the Dialogue:**
+This response reframes the entire problem. The paradigm's core argument is that the true fear should not be directed at the volume of explicit type declarations (the "boilerplate"), but at the scattered, implicit rules and validations that haunt a traditional codebase. The declaration of types is not a chore; it is the **sanctification of business rules**. The value of consolidating this logic into a single, authoritative, and reusable place far outweighs the initial effort of type creation, especially in an era of AI-assisted code generation.
+
+---
+
+### 2. On the Practicality of "Perfect Metamorphosis"
+
+**The Question:**
+The "metamorphosis" metaphor is powerful, but real-world software development is often more chaotic. How does this elegant model of "from one complete existence to the next" handle processes that are incomplete, time-consuming, or asynchronous, such as waiting for an external API call or handling a retryable partial failure?
+
+**The Architect's Answer:**
+> It is not your responsibility to *perform* the metamorphosis. Your only responsibility is to declare what you want to become based on your given environment (the constructor arguments), and expose that new self through your public properties. In other words, for a `Request` object to transform into a `Result` object is the framework's job. Through metadata in attributes, the framework might decide to give up after 30 seconds, it might be retrying, or it might be handling it asynchronously. You only declare your state; you do not control the execution.
+
+**Insight from the Dialogue:**
+This is a masterful application of the "Separation of Concerns" principle, redefined for this paradigm. An object's responsibility is strictly limited to defining its state (**What** it is). The **execution method ("How")** of its state transition—be it synchronous, asynchronous, or with retries—is decoupled from the object's business logic. This responsibility is delegated to the framework, which interprets declarative metadata (e.g., attributes) to orchestrate the flow. This allows domain objects to remain pure and testable while enabling complex, real-world execution strategies.
+
+---
+
+### 3. On the Philosophy of "Error" as an Existence
+
+**The Question:**
+This paradigm aims to "make errors impossible to exist." However, events like "out of stock" or "credit card declined" are not program bugs but valid, important business "existences." By modeling them as normal branches of a flow, like `UserConflict`, don't you risk blurring the semantics of what constitutes a "success" versus a business "failure"?
+
+**The Architect's Answer:**
+> You must not confuse unexpected exceptions with predictable errors. A system might require a database connection to function; if it's unavailable, that should be treated as an exception. However, if you are dealing with predictable issues like invalid user input, your object should simply report the problem to an injected `ErrorReporter` or a `Problem/Issue` object. In its next metamorphosis, it might become an `InvalidUser` or be reverted to a `Request` state. True exceptions should be passed to a root exception handler. They should only represent unrecoverable situations and should never be used for control flow.
+
+**Insight from the Dialogue:**
+The architect's response draws a critical line between **predictable business outcomes** and **unrecoverable system anomalies**. The paradigm doesn't eliminate errors; it forces them to be classified. Predictable results, whether "successful" or not (e.g., `ValidUser`, `InvalidUser`, `OutOfStock`), are modeled as part of the domain's explicit "existences." Only true system-level failures that prevent the application from functioning as designed (e.g., a lost database connection) are treated as traditional exceptions. This forces a more robust and honest design.
+
+---
+
+### 4. On Immutability and System Evolution
+
+**The Question:**
+Does the principle of "existence is immutable" sacrifice the system's ability to change and evolve easily? For instance, if you have a `PositiveInteger` existence, and a business requirement changes to allow non-negative integers (including zero), do you have to rewrite all dependent code?
+
+**The Architect's Answer:**
+> If the requirement changes to allow non-negative integers, only the rule within the `Validation` class needs to be modified. In a traditional system, you would have to find and change every scattered validation. Furthermore, in this architecture, all dependencies are provided through interfaces. This is the most change-resilient architecture imaginable. The destination of a `Be` attribute does not have to be a concrete class; you can specify an interface, abstracting the destination of the metamorphosis.
+
+**Insight from the Dialogue:**
+This answer reveals that the architecture's strength lies in its structural separation of **what is stable (the contracts, i.e., types and interfaces)** from **what is volatile (the implementation details, like specific validation logic)**. Because the validation rule is centralized, changing it is simple. More profoundly, by depending on interfaces for state transitions (`Be(MyInterface::class)`), the system is insulated from changes in concrete implementations. Immutability, therefore, does not lead to rigidity. Instead, it creates a stable foundation upon which flexible and safe evolution can occur.

--- a/docs/FAQ-semantic-variable-names.md
+++ b/docs/FAQ-semantic-variable-names.md
@@ -1,0 +1,96 @@
+# Semantic Variable Names: The Attempt to Encode Meaning in Names
+
+## Overview
+
+Semantic Variable Names is a design approach in which variable names carry meaning and validation contracts. It introduces a semantic dimension into code, complementing the structural guarantees of type systems with naming conventions that encode intent, validity, and domain knowledge.
+
+This document presents objections to the concept, counterarguments, and deeper philosophical reflections, revealing the structural foundations and potential of this design philosophy.
+
+---
+
+## Objections and Counterarguments
+
+### Objection A: The Cost of Maintaining a Global Vocabulary Space
+
+**Counterargument:** This is not a cost but an investment in semantic integrity. As with type systems, introducing order reduces freedom but fosters consistency and clarity.
+
+---
+
+### Objection B: Who Owns the Meaning?
+
+**Counterargument:** Semantic Variable Names delegate meaning to teams and documentation artifacts (e.g., ALPS), enabling shared understanding and freedom from individual interpretation.
+
+---
+
+### Objection C: Can It Replace Types as a Central Concept?
+
+**Counterargument:** It’s not a replacement but a complement. Semantic Variable Names introduce a second dimension of validation—meaning—alongside type (structure). Existence = Type × Meaning × Validation.
+
+---
+
+## Fundamental Objections
+
+### Objection D: Can Meaning Truly Reside in Names?
+
+Meaning may arise from use, context, and action, not from static names.
+
+**Response:** Names aren’t meaning themselves, but placeholders that invite it. Semantic Variable Names provide a structured surface for meaning to emerge and be validated.
+
+---
+
+### Objection E: Does Fixing Meaning Hinder Evolution?
+
+By defining meaning too rigidly, we may stifle future flexibility.
+
+**Response:** As long as the system embraces evolvability (e.g., ALPS updates, folder reconfiguration), fixed semantics act as a visible boundary rather than a prison. Explicit ambiguity enables deliberate change.
+
+---
+
+### Objection F: Is This “Meaning” Truly Semantic?
+
+Are we calling usage constraints “meaning”? Is this semantics or its simulation?
+
+**Response:** This is a profound question. The “meaning” in Semantic Variable Names is not the whole of semantics, but a preparation for semantic emergence. As types define structure, names define intent. Meaning begins at the name.
+
+---
+
+### Objection G: What If the Meaning of a Name Is Violated?
+
+For example, what if `$userId` is sometimes an integer and sometimes a UUID?
+
+**Response:** In Semantic Variable Names, the meaning of a name is always enforced by validation. The contract cannot be silently violated—attempts to misuse a variable are surfaced immediately by design. This isn’t a convention; it’s a mechanism. Meaning is not just implied but actively protected.
+
+---
+
+## Meaning in Literature, Conversation, and Programs
+
+*   **Literature**: Ambiguity enriches expression; meaning is left to the reader.
+*   **Conversation**: Meaning emerges dynamically in context.
+*   **Programming**: Meaning must be explicit and verifiable.
+
+Semantic Variable Names operate in the third domain, but echo the literary idea that form (like haiku’s 5-7-5) enables creativity through constraint.
+
+---
+
+## Redefining Semantic Variable Names
+
+> Semantic Variable Names are an attempt to reflect meaning on the syntactic surface.
+
+### They enable:
+
+*   📌 Explicit intent
+*   🔍 Validatable semantics
+*   📖 Shared vocabulary
+*   🛡️ Defensive design
+*   🌐 Ontological clarity
+
+---
+
+## Conclusion
+
+Semantic Variable Names are more than a design tool—they are a philosophical lens for addressing the relationship between **naming and being** in software. They link types, safety, expression, intention, context, and verification.
+
+Rather than “fixing” meaning, they prepare the stage for it to emerge.
+
+They are not the meaning itself, but the surface where meaning appears and is tested. In this sense, they are a doorway into a deeper paradigm of **ontological and metamorphic programming**.
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,32 +1,159 @@
-# Ray.Framework Documentation
+# Documentation for the Ontological Programming Paradigm
 
-This directory contains the foundational documents for Ray.Framework:
+Welcome to the documentation hub for a new way of thinking about software. This collection of documents outlines **Ontological Programming**, a paradigm that shifts focus from "doing" to "being," and its practical implementation, **Ray.Framework**.
 
-## Core Documents
+Here, you will not just find technical specifications, but a complete philosophy for building software that is reliable, understandable, and correct by its very nature.
 
-### [Ontological Programming: A New Paradigm](ontological-programming-paper.md)
-The philosophical foundation that introduces Ontological Programming—a paradigm where we program by defining what can exist, rather than what should happen. This document explores the theoretical underpinnings that inspired Ray.Framework.
+## Reading Guide: Where to Start
 
-### [Ray.Framework Whitepaper](ray-framework-whitepaper.md)
-The philosophical and technical foundations of Ray.Framework. This document shows how Ray.Framework implements the Ontological Programming concepts through the Metamorphic Programming paradigm.
+We recommend reading the documents in order, as each builds upon the concepts of the previous one. This journey will take you from high-level philosophy to concrete implementation patterns.
 
-### [Metamorphosis Architecture Manifesto](metamorphosis-architecture-manifesto.md)
-A practical guide to implementing the Metamorphosis Architecture. This document provides concrete patterns, including the Traffic Controller pattern for branching and the Spy pattern for testing.
+### 1. **[Ontological Programming: A New Paradigm](./ontological-programming-paper.md)**
 
-### [UNIX Pipes and Ray.Framework](unix-pipes-vs-ray-framework.md)
-An illuminating comparison between UNIX pipes and Ray.Framework, showing how the pipeline philosophy evolves from text streams to typed domain objects. Essential reading for understanding Ray.Framework's place in computing history.
+> **"What if we programmed by defining what can exist, rather than what should happen?"**
 
-## Reading Order
+**Start here.** This is the foundational philosophical paper that introduces the core ideas of Ontological Programming. It establishes the "Why?" behind this entire ecosystem.
 
-1. Start with **Ontological Programming** to understand the fundamental philosophy
-2. Continue with the **Ray.Framework Whitepaper** to see how these concepts are realized
-3. Then read the **Manifesto** for practical implementation guidance
-4. Explore **UNIX Pipes and Ray.Framework** to understand the historical context and evolution
+*   **Read this to understand:**
+    *   The core crisis in traditional programming ("The Crisis of Doing").
+    *   The five fundamental principles of existence-driven design.
+    *   How this paradigm promises to eliminate entire classes of errors.
+    *   The role of the programmer in the age of AI.
 
-## Conceptual Hierarchy
+### 2. **[Ray.Framework: Programming as Metamorphosis](./ray-framework-whitepaper.md)**
 
-Ontological Programming (Philosophy)
-↓
-Ray.Framework (Framework Design)
-↓
-Metamorphosis Architecture (Implementation Patterns)
+> **"Objects are processed through constructor injection, just as light rays pass through a prism - instant, pure, and transformed."**
+
+This whitepaper details **Ray.Framework**, the concrete PHP implementation of Ontological Programming. It translates the abstract philosophy into a practical, powerful tool.
+
+*   **Read this to understand:**
+    *   How constructors become "workshops" for self-transformation.
+    *   The Metamorphosis Pattern (`Egg → Larva → Pupa → Butterfly`).
+    *   The duality of linear chains and parallel assemblies for data flow.
+    *   How automatic streaming and type transparency are achieved.
+
+### 3. **[The Metamorphosis Architecture Manifesto](./metamorphosis-architecture-manifesto.md)**
+
+> **(This document is implicitly referenced but would be the next logical step)**
+
+This manifesto is the practical "how-to" guide for architects and developers. It provides detailed patterns, testing strategies, and conventions for building systems with Ray.Framework.
+
+*   **Read this to learn:**
+    *   The `Type-Driven Metamorphosis` pattern for handling conditional logic.
+    *   The `Unchanged Name Principle` for maintaining semantic continuity.
+    *   Advanced testing strategies for ontological systems.
+
+### 4. **[The #[Accept] Pattern: Ontological Delegation](./accept-pattern-ontological-delegation.md)**
+
+> **"The highest intelligence is knowing when to seek the wisdom of others."**
+
+This document introduces a mature pattern for handling real-world complexity. It addresses the question: "What happens when an object cannot determine its own existence?"
+
+*   **Read this to explore:**
+    *   How to model delegation to experts (`Physician`, `Lawyer`, `Engineer`).
+    *   The `Undetermined` state and the `#[Accept]` attribute.
+    *   How this pattern makes systems more robust and realistic.
+
+### 5. **Supporting Documents: The Ecosystem Tools**
+
+These documents describe the powerful tooling and integrations that emerge from this paradigm.
+
+*   **[Architecture as Documentation](./architecture-as-documentation.md)**
+    *   Discover how the architecture itself becomes the ultimate, always-up-to-date documentation.
+    *   Learn about the `ray-tree` command for automatically visualizing your system's structure, semantics, and data flows.
+
+*   **[ALPS and Ray.Framework: Bidirectional Generation](./alps-ray-bidirectional-generation.md)**
+    *   Explore the revolutionary concept of bidirectional generation between design specifications (ALPS) and executable code.
+    *   See how a single, protocol-agnostic design can generate REST, GraphQL, or gRPC APIs.
+
+## The Complete Vision
+
+This collection of documents presents more than just a framework. It offers a complete, cohesive vision for software development where:
+
+*   **Philosophy** (`Ontological Programming`) provides the "Why".
+*   **Implementation** (`Ray.Framework`) provides the "How".
+*   **Patterns** (`#[Accept]`, `Metamorphosis`) provide the "What".
+*   **Tooling** (`Architecture as Documentation`, `ALPS Generation`) provides the "With".
+
+We invite you to embark on this journey and discover a new way to create software—not by writing fragile instructions, but by defining robust, beautiful, and correct existences.
+
+---
+
+# 存在論的プログラミング・パラダイムのドキュメント
+
+ソフトウェアについての新しい考え方へようこそ。このドキュメント群は、「何をするか」から「何であるか」へとフォーカスを移す**存在論的プログラミング**とその実装である**Ray.Framework**を紹介します。
+
+ここでは技術仕様だけでなく、本質的に信頼性が高く、理解しやすく、正しいソフトウェアを構築するための完全な哲学を見つけることができます。
+
+## 読書ガイド：どこから始めるか
+
+各文書は前の概念を基に構築されているため、順番に読むことをお勧めします。この旅は、高レベルの哲学から具体的な実装パターンまでを案内します。
+
+### 1. **[存在論的プログラミング：新しいパラダイム](./ontological-programming-paper.md)**
+
+> **「何が起こるべきかではなく、何が存在できるかを定義してプログラムを書いたらどうだろうか？」**
+
+**ここから始めてください。** これは存在論的プログラミングの核心となる考えを紹介する基礎的な哲学論文です。この全体的なエコシステムの「なぜ？」を確立します。
+
+*   **理解すべき内容:**
+    *   従来のプログラミングにおける核心的な危機（「行動の危機」）
+    *   存在駆動設計の5つの基本原則
+    *   このパラダイムが約束する全体的なエラークラスの排除
+    *   AI時代におけるプログラマーの役割
+
+### 2. **[Ray.Framework：変容としてのプログラミング](./ray-framework-whitepaper.md)**
+
+> **「オブジェクトは光線がプリズムを通過するように、コンストラクタ注入を通じて処理される—瞬間的で、純粋で、変容される。」**
+
+この白書では、存在論的プログラミングの具体的なPHP実装である**Ray.Framework**を詳述します。抽象的な哲学を実用的で強力なツールに変換します。
+
+*   **理解すべき内容:**
+    *   コンストラクタが自己変容の「工房」となる方法
+    *   変容パターン（`卵 → 幼虫 → 蛹 → 蝶`）
+    *   データフローにおける線形チェーンと並列アセンブリの二重性
+    *   自動ストリーミングと型透明性の実現方法
+
+### 3. **[変容アーキテクチャ・マニフェスト](./metamorphosis-architecture-manifesto.md)**
+
+> **（この文書は暗黙的に参照されていますが、次の論理的ステップとなります）**
+
+このマニフェストは、アーキテクトと開発者のための実用的な「ハウツー」ガイドです。Ray.Frameworkを使用してシステムを構築するための詳細なパターン、テスト戦略、規約を提供します。
+
+*   **学ぶべき内容:**
+    *   条件ロジックを処理するための`型駆動変容`パターン
+    *   意味論的継続性を維持するための`名前不変原則`
+    *   存在論的システムのための高度なテスト戦略
+
+### 4. **[#[Accept]パターン：存在論的委譲](./accept-pattern-ontological-delegation.md)**
+
+> **「最高の知性は、他者の知恵を求める時を知ることである。」**
+
+この文書では、現実世界の複雑さを処理するための成熟したパターンを紹介します。「オブジェクトが自らの存在を決定できない場合はどうなるか？」という問いに答えます。
+
+*   **探求すべき内容:**
+    *   専門家（`医師`、`弁護士`、`エンジニア`）への委譲のモデル化
+    *   `未決定`状態と`#[Accept]`属性
+    *   このパターンがシステムをより堅牢で現実的にする方法
+
+### 5. **サポート文書：エコシステムツール**
+
+これらの文書では、このパラダイムから生まれる強力なツールと統合について説明します。
+
+*   **[ドキュメントとしてのアーキテクチャ](./architecture-as-documentation.md)**
+    *   アーキテクチャ自体が最終的な、常に最新のドキュメントとなる方法を発見
+    *   システムの構造、意味論、データフローを自動的に可視化する`ray-tree`コマンドについて学習
+
+*   **[ALPSとRay.Framework：双方向生成](./alps-ray-bidirectional-generation.md)**
+    *   設計仕様（ALPS）と実行可能コード間の双方向生成の革命的概念を探求
+    *   単一のプロトコル非依存設計がREST、GraphQL、またはgRPC APIを生成する方法を確認
+
+## 完全なビジョン
+
+このドキュメント群は単なるフレームワーク以上のものを提示します。ソフトウェア開発のための完全で一貫したビジョンを提供します：
+
+*   **哲学**（`存在論的プログラミング`）が「なぜ」を提供
+*   **実装**（`Ray.Framework`）が「どのように」を提供
+*   **パターン**（`#[Accept]`、`変容`）が「何を」を提供
+*   **ツール**（`ドキュメントとしてのアーキテクチャ`、`ALPS生成`）が「何によって」を提供
+
+私たちは、この旅に乗り出し、ソフトウェアを作成する新しい方法を発見することをお勧めします—脆弱な指示を書くのではなく、堅牢で美しく、正しい存在を定義することによって。


### PR DESCRIPTION
## Summary

- Add FAQ-dialogue-with-architect.md: Practical Q&A addressing design concerns through architect dialogue
- Add FAQ-semantic-variable-names.md: Philosophical exploration of naming conventions and semantic validation
- Enhance docs/README.md with comprehensive reading guide in both English and Japanese
- Create structured documentation journey from philosophy to implementation

## Key Additions

### FAQ Documents
- **FAQ-dialogue-with-architect.md**: Addresses practical concerns like existential explosion, async processing, error handling, and system evolution through a dialogue format
- **FAQ-semantic-variable-names.md**: Deep dive into semantic variable naming with objections, counterarguments, and philosophical reflections

### Documentation Guide
- **Bilingual README**: Complete reading guide in both English and Japanese
- **Structured Journey**: Philosophy → Implementation → Patterns → Tools
- **Clear Value Propositions**: Each document's benefits clearly explained

## Test plan

- [x] Verify all new files are properly formatted and readable
- [x] Check that internal links work correctly
- [x] Ensure bilingual content maintains consistency
- [x] Confirm documentation structure flows logically

🤖 Generated with [Claude Code](https://claude.ai/code)

## Sourceryによるサマリー

アーキテクトとの対話とセマンティック変数命名に関する包括的なFAQドキュメントを2つ追加し、ドキュメントを刷新して、高レベルの哲学から実践的な実装パターンやツールに至るまで、バイリンガルで構造化された読書体験を提供します。

新機能：
- 実践的な設計およびシステム進化に関する質問に対処するための、対話形式のFAQ（docs/FAQ-dialogue-with-architect.md）を導入
- 命名規則の哲学的および検証的側面を探求する、セマンティック変数名FAQ（docs/FAQ-semantic-variable-names.md）を追加

機能拡張：
- docs/README.mdを、哲学、フレームワークのホワイトペーパー、アーキテクチャパターン、およびツールにまたがる明確なステップバイステップの読書ガイドに再構築
- 一貫性のあるアクセス可能なガイダンスのために、メインのドキュメントハブでバイリンガル（英語/日本語）のドキュメントを提供

ドキュメンテーション：
- ルートのREADME.mdを更新して、新しいFAQドキュメントの名前を変更してリンクし、拡張されたドキュメント構造を反映

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add two comprehensive FAQ documents on architect dialogue and semantic variable naming, and revamp the documentation with a bilingual, structured reading journey from high-level philosophy through practical implementation patterns and tooling.

New Features:
- Introduce a dialogue-based FAQ (docs/FAQ-dialogue-with-architect.md) to address practical design and system-evolution questions
- Add a semantic-variable-names FAQ (docs/FAQ-semantic-variable-names.md) exploring philosophical and validation aspects of naming conventions

Enhancements:
- Restructure docs/README.md into a clear, step-by-step reading guide spanning philosophy, framework whitepaper, architecture patterns, and tooling
- Provide bilingual (English/Japanese) documentation in the main docs hub for consistent, accessible guidance

Documentation:
- Update the root README.md to rename and link the new FAQ documents and reflect the expanded documentation structure

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README to provide a comprehensive, bilingual introduction to Ontological Programming and Ray.Framework, including detailed reading guidance and vision statements.
  * Corrected and consolidated FAQ links in the README.
  * Added a new FAQ document featuring a dialogue on architectural principles.
  * Introduced a new FAQ on Semantic Variable Names, outlining their significance and addressing common objections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->