### PR TITLE
Add Being Paradigm Structure and terminology document

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -102,6 +102,11 @@ This document introduces a mature pattern for handling real-world complexity. It
 
 These documents describe the powerful tooling and integrations that emerge from this paradigm.
 
+*   **[Being Paradigm Structure](./framework/being-paradigm-structure.md)**
+  * Navigate the complete conceptual map of Being-Oriented Programming.
+  * Understand the hierarchical relationship between ontological principles and practical implementation.
+  * Essential reference for grasping the full scope of the paradigm.
+
 *   **[Architecture as Documentation](./framework/architecture-as-documentation.md)**
   * Discover how the architecture itself becomes the ultimate, always-up-to-date documentation.
   * Learn about the `ray-tree` command for automatically visualizing your system's structure, semantics, and data flows.
@@ -229,6 +234,11 @@ We invite you to embark on this journey and discover a new way to create softwar
 ### 9. **サポート文書：エコシステムツール**
 
 これらの文書では、このパラダイムから生まれる強力なツールと統合について説明します。
+
+*   **[Being Paradigm構造](./framework/being-paradigm-structure.md)**
+    *   Being指向プログラミングの完全な概念マップをナビゲート
+    *   存在論的原理と実践的実装の階層関係を理解
+    *   パラダイムの全範囲を把握するための必須リファレンス
 
 *   **[ドキュメントとしてのアーキテクチャ](./framework/architecture-as-documentation.md)**
     *   アーキテクチャ自体が最終的な、常に最新のドキュメントとなる方法を発見

--- a/docs/README.md
+++ b/docs/README.md
@@ -115,6 +115,10 @@ These documents describe the powerful tooling and integrations that emerge from 
   * Explore the revolutionary concept of bidirectional generation between design specifications (ALPS) and executable code.
   * See how a single, protocol-agnostic design can generate REST, GraphQL, or gRPC APIs.
 
+*   **[Framework Terminology](./framework/terminology.md)**
+*   Essential glossary of terms used throughout the Ontological Programming paradigm and Ray.Framework.
+*   Defines key concepts like "being," "metamorphosis," and ontological patterns for quick reference.
+
 ## The Complete Vision
 
 Imagine what we can create with new vision — from doing to being, building software that defines existence itself rather than layering instructions.
@@ -247,6 +251,10 @@ We invite you to embark on this journey and discover a new way to create softwar
 *   **[ALPSとRay.Framework：双方向生成](./integration/alps-ray-bidirectional-generation.md)**
     *   設計仕様（ALPS）と実行可能コード間の双方向生成の革命的概念を探求
     *   単一のプロトコル非依存設計がREST、GraphQL、またはgRPC APIを生成する方法を確認
+
+*   **[フレームワーク用語集](./framework/terminology.md)**
+    *   存在論的プログラミング・パラダイムとRay.Framework全体で使用される用語の必須用語集。
+    *   「being」、「metamorphosis」、存在論的パターンなどのキー概念を定義し、クイックリファレンスとして利用可能。
 
 ## 完全なビジョン
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -130,8 +130,6 @@ This collection of documents presents more than just a framework. It offers a co
 *   **Patterns** (`#[Accept]`, `Metamorphosis`) provide the "What".
 *   **Tooling** (`Architecture as Documentation`, `ALPS Generation`) provides the "With".
 
-We invite you to embark on this journey and discover a new way to create software—not by writing fragile instructions, but by defining robust, beautiful, and correct existences.
-
 ---
 
 # 存在論的プログラミング・パラダイムのドキュメント
@@ -266,5 +264,3 @@ Imagine what we can create with new vision — doingからbeingへ、命令を�
 *   **実装**（`Ray.Framework`）が「どのように」を提供
 *   **パターン**（`#[Accept]`、`変容`）が「何を」を提供
 *   **ツール**（`ドキュメントとしてのアーキテクチャ`、`ALPS生成`）が「何によって」を提供
-
-私たちは、この旅に乗り出し、ソフトウェアを作成する新しい方法を発見することをお勧めします—脆弱な指示を書くのではなく、堅牢で美しく、正しい存在を定義することによって。

--- a/docs/framework/being-paradigm-structure.md
+++ b/docs/framework/being-paradigm-structure.md
@@ -1,0 +1,52 @@
+# Being Paradigm Structure
+
+```text
+Being Paradigm
+├── ⭐ Ontological Programming
+│   ├── 🔑 Being Class
+│   │   ├── Core Principles
+│   │   │   ├── Existence Precedes Action
+│   │   │   ├── Existence as Proof
+│   │   │   │   ├── Construction is Proof
+│   │   │   │   └── Semantic Variables are Proof
+│   │   │   ├── Being is Immutable
+│   │   │   ├── Impossibility over Error Handling
+│   │   │   └── Composition is Existence Dependency
+│   │   ├── Temporal Being
+│   │   ├── Nature
+│   │   ├── Subject-Object Unity
+│   │   └── "Becoming who you want to be through your nature"
+│   ├── 🔑 Existence Contract
+│   ├── Constructor Workshop Theory
+│   ├── Semantic Variable Names
+│   ├── SchemaLogger (Complete Execution Story)
+│   ├── AMD (Augmented Decision Making)
+│   │   ├── #[Accept] Attribute (Accepting Uncertainty)
+│   │   ├── Undetermined State (Wisdom of Not Knowing)
+│   │   ├── Context Preservation (Rich Context Maintenance)
+│   │   └── Decision Transparency (determine/ folder structure)
+└── ⭐ Metamorphic Programming
+    ├── Framework Implementation
+    │   ├── 🔑 #[Be] Attribute (Ontological Declaration)
+    │   ├── #[Input] Attribute (Inheritance from Previous Stage)
+    │   ├── #[Inject] Attribute (Transient Capability Injection)
+    │   └── Public Readonly Properties
+    ├── 🔑 Type-Driven Metamorphosis
+    │   ├── The Being Property (Ontological Self-Determination)
+    │   ├── Existential Question
+    │   ├── Union Type Destiny
+    │   └── Unchanged Name Principle
+    ├── Metamorphosis Patterns
+    │   ├── Linear Metamorphic Chain
+    │   ├── Fork-Join Pattern (Parallel Assembly)
+    │   ├── Parallel Assembly
+    │   └── Natural Progression
+    ├── Self-Transformation
+    ├── Input vs Being Distinction
+    └── ⭐ being life (Objects that exist, change, and have meaning)
+```
+
+#### Legend
+- ⭐ = Core Concepts (Foundation of the paradigm)
+- 🔑 = Essential Implementation Concepts (Required for understanding and implementation)
+

--- a/docs/framework/terminology.md
+++ b/docs/framework/terminology.md
@@ -1,0 +1,113 @@
+# Being Paradigm Terminology
+
+A concise glossary of key terms in the Being Paradigm, listed alphabetically for quick reference.
+
+## A
+
+### Augmented Decision Making (AMD)
+An approach combining deterministic rules, AI pattern recognition, and human intuition to handle complex decisions. Preserves rich context and embraces uncertainty through Undetermined states.
+
+## B
+
+### #[Be] Attribute
+A declaration of what an object is destined to become. Enables Type-Driven Metamorphosis by mapping object types to their next transformation stage.  
+*Example: `#[Be([Success::class, Failure::class])]`
+
+### Being Class
+The foundational concept in Ontological Programming representing objects that exist in time, carry their nature, and undergo self-determined transformation. Embodies temporal existence and subject-object unity.
+
+### being life
+Objects that exist, change, and have meaning. The ultimate expression of the Being Paradigm where code becomes alive through the integration of Being + Change + Meaning.
+
+### Being Property
+A special property (typically `$being`) using union types to express an object's potential futures or destiny. Enables internal self-determination.  
+*Example: `public readonly Success|Failure $being;`
+
+## C
+
+### Constructor Workshop Theory
+The principle that constructors are complete workshops of transformation where all logic resides, tools are used once, and the transformed self emerges immutable.
+
+## E
+
+### Existence as Proof
+The principle that if something exists, it is correct by definition. Encompasses both Construction is Proof and Semantic Variables are Proof.
+
+### Existence Contract
+A declaration of what must exist for an entity to exist, what it is when it exists, and what its existence enables.
+
+### Existential Question
+The internal process by which objects discover their own nature through self-assessment, typically expressed as "Who am I?" in the being property.
+
+## F
+
+### Fork-Join Pattern
+A parallel assembly pattern where a single context initiates multiple parallel transformations that later converge into a composite object.
+
+## I
+
+### #[Input] Attribute
+Marks constructor parameters that inherit data from the previous metamorphosis stage.
+
+### #[Inject] Attribute
+Marks constructor parameters that receive transient capabilities from the dependency injection container.
+
+## L
+
+### Linear Metamorphic Chain
+A sequential transformation pattern where each stage leads deterministically to the next: A → B → C → D.
+
+## M
+
+### Metamorphic Programming
+The implementation layer of the Being Paradigm focusing on object transformation through stages of existence.
+
+## N
+
+### Nature
+The inherent essence of a Being that guides its transformation without external control.
+
+## O
+
+### Ontological Programming
+A programming paradigm where objects focus on "being" rather than "doing," modeling software after existential concepts with immutability and self-determination.
+
+## P
+
+### Public Readonly Properties
+The principle that all object properties are public and immutable, ensuring transparency and preventing state mutation.
+
+## S
+
+### SchemaLogger
+A logging mechanism capturing complete execution stories as structured logs, enabling AI analysis to discover potential object evolutions.
+
+### Semantic Variable Names
+Variable names that carry meaning and validation contracts, where the existence of a properly named variable serves as proof of its validity.
+
+### Subject-Object Unity
+The philosophical principle that in the Being Paradigm, all objects are their own subjects—there is no external controller commanding objects.
+
+## T
+
+### Temporal Being
+The aspect of Being Classes that exist in time with memory of past and knowledge of potential futures.
+
+### Type-Driven Metamorphosis
+The mechanism where objects use union types and the being property to self-determine their next form, eliminating explicit control flow.
+
+## U
+
+### Unchanged Name Principle
+The principle that property names remain consistent across metamorphic stages to preserve identity and continuity through transformation.
+
+### Undetermined State
+A state representing an object's honest acknowledgment of its limitations, triggering delegation to appropriate expertise through the #[Accept] pattern.
+
+### Union Type Destiny
+The use of union types to express all possible futures an object might inhabit, serving as destiny maps rather than classifications.
+
+## W
+
+### "Whether?"
+The fundamental question of Ontological Programming—asking what can exist rather than how things should be done. Contrasts with "How?" (Imperative), "Who?" (OOP), and "What?" (Functional).

--- a/docs/philosophy/being-paradigm-when-object-gets-its-becoming.md
+++ b/docs/philosophy/being-paradigm-when-object-gets-its-becoming.md
@@ -453,6 +453,12 @@ Everything flows. All things are impermanent. And in this constant becoming, we 
 
 [The references section would include relevant philosophical works from both Eastern and Western traditions, programming paradigm literature, and the Ray.Framework documentation]
 
+### Related Documentation
+
+For a comprehensive overview of how the concepts presented in this paper fit into the broader Being Paradigm framework, see:
+
+- **[Being Paradigm Structure](../framework/being-paradigm-structure.md)** - Complete conceptual map showing the hierarchical relationship between ontological principles and practical implementation patterns
+
 ---
 
 ## Acknowledgments

--- a/docs/philosophy/wu-wei-software-design.md
+++ b/docs/philosophy/wu-wei-software-design.md
@@ -635,3 +635,11 @@ The way of water guides us. Wu wei wisdom illuminates the path. The future of so
 The journey continues, but the direction is clear. Flow with the current, not against it. Enable transformation, don't force it. Understand deeply, control lightly.
 
 In the end, the most profound systems are those that need no controller, because each part knows its way.
+
+---
+
+## Related Documentation
+
+For a comprehensive overview of how Wu Wei principles fit into the broader Being Paradigm framework, see:
+
+- **[Being Paradigm Structure](../framework/being-paradigm-structure.md)** - Complete conceptual map showing how Wu Wei principles integrate with ontological programming concepts and practical implementation patterns


### PR DESCRIPTION
- Add reference from Being Paradigm paper to structure document
- Add reference from Wu Wei document to structure document
- Improves document discoverability and navigation
- Helps readers understand the broader framework context
- Add terminology document

## Sourceryによるサマリー

Wu WeiとBeing ParadigmのドキュメントからBeing Paradigm Structureドキュメントへの相互参照を追加し、発見可能性とナビゲーションを向上させます。

ドキュメント：
- `wu-wei-software-design.md`に、Being Paradigm Structureドキュメントへのリンクを含む「関連ドキュメント」セクションを挿入します。
- `being-paradigm-when-object-gets-its-becoming.md`に、Being Paradigm Structureドキュメントへのリンクを含む「関連ドキュメント」セクションを挿入します。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add cross-references from Wu Wei and Being Paradigm documents to the Being Paradigm Structure document to improve discoverability and navigation

Documentation:
- Insert 'Related Documentation' section in wu-wei-software-design.md linking to the Being Paradigm Structure document
- Insert 'Related Documentation' section in being-paradigm-when-object-gets-its-becoming.md linking to the Being Paradigm Structure document

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added "Related Documentation" sections linking to the new "Being Paradigm Structure" document in key philosophy articles.
  * Introduced the "Being Paradigm Structure" document outlining the hierarchical framework and core concepts of the Being Paradigm.
  * Added a comprehensive glossary document defining key terms and concepts of the Being Paradigm.
  * Updated the README to include the new "Being Paradigm Structure" and "Framework Terminology" as essential supporting references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->